### PR TITLE
Develop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "doit"
-version = "1.0.0"
+version = "1.2.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 3
 
 [[package]]
 name = "doit"
-version = "1.2.0"
+version = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "doit"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "doit"
-version = "1.0.0"
+version = "1.2.0"
 edition = "2021"

--- a/do.it
+++ b/do.it
@@ -15,4 +15,27 @@ lint {
 	@ Test project
 	$ cargo clippy --all-targets --all-features -- -D warnings $@
 }
+pack {
+	@ Pack the binaries into a zip and tarball
+	ZIP = "doit.elf64.zip"
+	TAR = "doit.elf64.tar.gz"
+	$$$
+	if [ ! -e "./target/release/doit" ] ; then
+		echo "Please run: \e[93mcargo build -r\e[0m"
+		exit 1
+	fi
+	if [ ! -$$(which zip) ] ; then
+		echo "Please install Zip: \e[93mapt install zip\e[0m"
+		exit 1
+	fi
+	cd ./target/release
+	if [ -e "$ZIP" ] ; then rm "$ZIP" ; fi
+	if [ -e "$TAR" ] ; then rm "$TAR" ; fi
+	zip "$ZIP" doit > /dev/null
+	echo "Zip: \e[93m$$(pwd)/$ZIP\e[0m"
+	tar -zcf "$TAR" doit > /dev/null
+	echo "Tar: \e[93m$$(pwd)/$TAR\e[0m"
+	cd - > /dev/null
+	$$$
+}
 compile_test: cd test-files && doit -f --keep $@

--- a/do.it
+++ b/do.it
@@ -1,8 +1,14 @@
 @ Project builder
 build {
-	@ Build help statement.
+	@ Build the current project. Use the '-r' flag to compile a new release build.
 	$ cargo build --color=always $@
 }
+
+release {
+	@ Build a release version and then pack it
+	$ cargo build -r --color=always && doit pack
+}
+
 clean {
 	@ Clean Project
 	$ cargo clean
@@ -17,9 +23,11 @@ lint {
 }
 pack {
 	@ Pack the binaries into a zip and tarball
-	ZIP = "doit.elf64.zip"
-	TAR = "doit.elf64.tar.gz"
 	$$$
+	VER=`./target/release/doit --version | tr '.' '_'`
+	ZIP="pack/doit_$$VER.elf64.zip"
+	TAR="pack/doit_$$VER.elf64.tar.gz"
+
 	if [ ! -e "./target/release/doit" ] ; then
 		echo "Please run: \e[93mcargo build -r\e[0m"
 		exit 1
@@ -28,13 +36,16 @@ pack {
 		echo "Please install Zip: \e[93mapt install zip\e[0m"
 		exit 1
 	fi
+	echo Packing './target/release'
+	if [ -e ./target/pack ]; then
+		rm -R ./target/pack
+	fi
+	mkdir ./target/pack
 	cd ./target/release
-	if [ -e "$ZIP" ] ; then rm "$ZIP" ; fi
-	if [ -e "$TAR" ] ; then rm "$TAR" ; fi
-	zip "$ZIP" doit > /dev/null
-	echo "Zip: \e[93m$$(pwd)/$ZIP\e[0m"
-	tar -zcf "$TAR" doit > /dev/null
-	echo "Tar: \e[93m$$(pwd)/$TAR\e[0m"
+	echo "Zip: \e[93m./target/$$ZIP\e[0m"
+	zip "../$$ZIP" doit > /dev/null
+	echo "Tar: \e[93m./target/$$TAR\e[0m"
+	tar -zcf "../$$TAR" doit > /dev/null
 	cd - > /dev/null
 	$$$
 }

--- a/src/generator/generators.rs
+++ b/src/generator/generators.rs
@@ -7,10 +7,10 @@ use crate::{
 
 pub fn node_value(node: &Node) -> &str {
 	let value = node.value.value.as_ref();
-	return match value {
+	match value {
 		Some(res) => AsRef::as_ref(res),
 		None => "",
-	};
+	}
 }
 
 pub fn generate_variable(node: &Node, exists: bool) -> Result<String, Error> {

--- a/src/lexer/lexers.rs
+++ b/src/lexer/lexers.rs
@@ -193,7 +193,7 @@ mod tests {
 	}
 	impl MockConsumer {
 		pub fn new(source: &str) -> MockConsumer {
-			return MockConsumer { index: 0, source: source.chars().collect() };
+			MockConsumer { index: 0, source: source.chars().collect() }
 		}
 	}
 	impl Consumer for MockConsumer {

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -117,7 +117,7 @@ impl Lexer<'_> {
 			Some(v) => v,
 			None => return Ok(Token::sym(TokenType::EOF)),
 		};
-		return if is_number(&next) {
+		if is_number(&next) {
 			match read_number(self) {
 				Ok(v) => Ok(Token::val(TokenType::LIT_NUM, Some(v.iter().collect()))),
 				Err(e) => self.generate_error(ErrorKind::InvalidData, &e),
@@ -165,7 +165,7 @@ impl Lexer<'_> {
 			Ok(Token::val(TokenType::HELP, Some(self.handle_error(help_block)?)))
 		} else {
 			Ok(Token::val(TokenType::SYMBOL, Some(self.consume().unwrap().to_string())))
-		};
+		}
 	}
 }
 

--- a/src/utils/hash/mod.rs
+++ b/src/utils/hash/mod.rs
@@ -1,0 +1,8 @@
+
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+pub fn calculate_hash<T: Hash>(data: &T) -> u64 {
+	let mut hasher = DefaultHasher::new();
+	data.hash(&mut hasher);
+	hasher.finish()
+}

--- a/src/utils/log/mod.rs
+++ b/src/utils/log/mod.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 
 pub fn debug(message: &str) {
-	println!("\x1b[42m DBG \x1b[0m \x1b[32m{message}\x1b[0m")
+	if cfg!(debug_assertions) {
+		println!("\x1b[42m DBG \x1b[0m \x1b[32m{message}\x1b[0m")
+	}
 }
 pub fn info(message: &str) {
 	println!("\x1b[44m INF \x1b[0m {message}")

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod log;
+pub mod hash;


### PR DESCRIPTION
- **Multi-Script Compiler Optimization:** Now when specifying the script to run with `-t`, doit will compile the script to its own unique directory in the `.doit/` folder. This allows you to have several scripts within the same directory, or in separate directories and execute all of them without having to recompile every time you switch scripts.
- **New `-c` Clean Flag:** When specifying the `-c` flag, all other flags will be ignored and a clean function will execute. This will simply delete the local `.doit/` directory. This can be tied into other clean scripts or processes to automate tidying up a directory.
- **Simpler Versioning:** Versioning is now pulled from the semantic version defined in the cargo.toml that Cargo bakes into the executable. This is much better then my previously hardcoded values. The print out is also a simpler `v1.2.3`.